### PR TITLE
[#39] 게시물 및 관련 레코드 삭제 비동기 처리 개발 완료

### DIFF
--- a/src/main/java/com/outstagram/outstagram/config/KafkaConsumerConfig.java
+++ b/src/main/java/com/outstagram/outstagram/config/KafkaConsumerConfig.java
@@ -20,7 +20,7 @@ public class KafkaConsumerConfig {
     private String bootstrapServers;
 
     @Bean
-    public ConsumerFactory<String, Long> consumerFactory() {
+    public ConsumerFactory<String, Long> feedConsumerFactory() {
         Map<String, Object> configProps = new HashMap<>();
 
         configProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
@@ -32,9 +32,29 @@ public class KafkaConsumerConfig {
     }
 
     @Bean
-    public ConcurrentKafkaListenerContainerFactory<String, Long> kafkaListenerContainerFactory() {
+    public ConsumerFactory<String, Long> postDeleteConsumerFactory() {
+        Map<String, Object> configProps = new HashMap<>();
+
+        configProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        configProps.put(ConsumerConfig.GROUP_ID_CONFIG, "post");
+        configProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        configProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, LongDeserializer.class);
+
+        return new DefaultKafkaConsumerFactory<>(configProps);
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, Long> feedKafkaListenerContainerFactory() {
         ConcurrentKafkaListenerContainerFactory<String, Long> factory = new ConcurrentKafkaListenerContainerFactory<>();
-        factory.setConsumerFactory(consumerFactory());
+        factory.setConsumerFactory(feedConsumerFactory());
+
+        return factory;
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, Long> postDeleteKafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, Long> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(postDeleteConsumerFactory());
 
         return factory;
     }

--- a/src/main/java/com/outstagram/outstagram/kafka/consumer/PostDeleteConsumer.java
+++ b/src/main/java/com/outstagram/outstagram/kafka/consumer/PostDeleteConsumer.java
@@ -1,0 +1,64 @@
+package com.outstagram.outstagram.kafka.consumer;
+
+import com.outstagram.outstagram.exception.ApiException;
+import com.outstagram.outstagram.exception.errorcode.ErrorCode;
+import com.outstagram.outstagram.mapper.BookmarkMapper;
+import com.outstagram.outstagram.mapper.CommentMapper;
+import com.outstagram.outstagram.mapper.ImageMapper;
+import com.outstagram.outstagram.mapper.LikeMapper;
+import com.outstagram.outstagram.mapper.PostMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class PostDeleteConsumer {
+
+    private final PostMapper postMapper;
+    private final LikeMapper likeMapper;
+    private final BookmarkMapper bookmarkMapper;
+    private final CommentMapper commentMapper;
+    private final ImageMapper imageMapper;
+
+    @KafkaListener(topics = "post-delete", groupId = "post", containerFactory = "postDeleteKafkaListenerContainerFactory")
+    public void receive(@Payload Long postId) {
+        log.info("=========== 게시물 관련 레코드 삭제 시작, postId = {}", postId);
+        // post에서 soft delete
+        int postResult = postMapper.deleteById(postId);
+        if (postResult == 0) {
+            throw new ApiException(ErrorCode.DELETE_ERROR, "게시물 삭제 오류 발생!!");
+        }
+
+        // like에서 hard delete
+        int likeResult = likeMapper.deleteByPostId(postId);
+        if (likeResult == 0) {
+            throw new ApiException(ErrorCode.DELETE_ERROR, "좋아요 삭제 오류 발생!!");
+        }
+
+        // bookmark에서 hard delete
+        int bookmarkResult = bookmarkMapper.deleteByPostId(postId);
+        if (bookmarkResult == 0) {
+            throw new ApiException(ErrorCode.DELETE_ERROR, "북마크 삭제 오류 발생!!");
+        }
+
+        // comment에서 soft delete
+        int commentResult = commentMapper.deleteByPostId(postId);
+        if (commentResult == 0) {
+            throw new ApiException(ErrorCode.DELETE_ERROR, "댓글 삭제 오류 발생!!");
+        }
+
+        // image에서 soft delete
+        int imageResult = imageMapper.deleteByPostId(postId);
+        if (imageResult == 0) {
+            throw new ApiException(ErrorCode.DELETE_ERROR, "이미지 기록 삭제 오류 발생!!");
+        }
+
+        log.info("=========== 게시물 관련 레코드 삭제 종료");
+    }
+
+
+}

--- a/src/main/java/com/outstagram/outstagram/kafka/producer/PostDeleteProducer.java
+++ b/src/main/java/com/outstagram/outstagram/kafka/producer/PostDeleteProducer.java
@@ -1,0 +1,18 @@
+package com.outstagram.outstagram.kafka.producer;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class PostDeleteProducer {
+    private final KafkaTemplate<String, Long> kafkaTemplate;
+
+    public void send(String topic, Long postId) {
+        log.info("sending postId = {} to topic = {}", postId, topic);
+        kafkaTemplate.send(topic, postId);
+    }
+}

--- a/src/main/java/com/outstagram/outstagram/mapper/BookmarkMapper.java
+++ b/src/main/java/com/outstagram/outstagram/mapper/BookmarkMapper.java
@@ -14,5 +14,8 @@ public interface BookmarkMapper {
 
     int deleteBookmark(Long userId, Long postId);
 
+    int deleteByPostId(Long postId);
+
+
     List<PostImageDTO> findWithPostsAndImageByUserId(Long userId, Long lastId, int size);
 }

--- a/src/main/java/com/outstagram/outstagram/mapper/CommentMapper.java
+++ b/src/main/java/com/outstagram/outstagram/mapper/CommentMapper.java
@@ -17,4 +17,6 @@ public interface CommentMapper {
     int updateContentsById(Long commentId, String contents);
 
     int deleteComment(Long commentId);
+
+    int deleteByPostId(Long postId);
 }

--- a/src/main/java/com/outstagram/outstagram/mapper/ImageMapper.java
+++ b/src/main/java/com/outstagram/outstagram/mapper/ImageMapper.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface ImageMapper {
 
-    int insertImages(List<ImageDTO> imageList);
+    void insertImages(List<ImageDTO> imageList);
 
     List<ImageDTO> findImagesByPostId(Long postId);
 
@@ -15,4 +15,6 @@ public interface ImageMapper {
      * soft delete 방식으로, is_deleted = 1로 업데이트함으로써, 삭제됨을 표현
      */
     int deleteByIds(List<Long> deleteImgIds);
+
+    int deleteByPostId(Long postId);
 }

--- a/src/main/java/com/outstagram/outstagram/mapper/LikeMapper.java
+++ b/src/main/java/com/outstagram/outstagram/mapper/LikeMapper.java
@@ -14,5 +14,7 @@ public interface LikeMapper {
 
     int deleteLike(Long userId, Long postId);
 
+    int deleteByPostId(Long postId);
+
     List<PostImageDTO> findWithPostsAndImageByUserId(Long userId, Long lastId, int size);
 }

--- a/src/main/resources/mybatis/mapper/bookmark.xml
+++ b/src/main/resources/mybatis/mapper/bookmark.xml
@@ -21,6 +21,11 @@
       AND post_id = #{postId}
   </delete>
 
+  <delete id="deleteByPostId">
+    DELETE FROM bookmark
+    WHERE post_id = #{postId}
+  </delete>
+
   <select id="findPostIdsByUserId" resultType="Long">
     SELECT post_id
     FROM bookmark

--- a/src/main/resources/mybatis/mapper/comment.xml
+++ b/src/main/resources/mybatis/mapper/comment.xml
@@ -74,69 +74,12 @@
     WHERE id = #{commentId} AND is_deleted = 0
   </delete>
 
-<!--  <select id="existsUserBookmark" resultType="boolean">-->
-<!--    SELECT CASE WHEN COUNT(*) > 0 THEN true ELSE false END-->
-<!--    FROM bookmark-->
-<!--    WHERE user_id = #{userId}-->
-<!--      AND post_id = #{postId}-->
-<!--  </select>-->
-
-<!--  <delete id="deleteBookmark">-->
-<!--    DELETE FROM bookmark-->
-<!--    WHERE user_id = #{userId}-->
-<!--      AND post_id = #{postId}-->
-<!--  </delete>-->
-
-<!--  <select id="findPostIdsByUserId" resultType="Long">-->
-<!--    SELECT post_id-->
-<!--    FROM bookmark-->
-<!--    WHERE user_id = #{userId}-->
-<!--  </select>-->
-
-<!--  <resultMap id="postImageDTOMap" type="com.outstagram.outstagram.dto.PostImageDTO">-->
-<!--    &lt;!&ndash; PostDTO의 필드 매핑 &ndash;&gt;-->
-<!--    <id property="id" column="post_id"/>-->
-<!--    <result property="contents" column="contents"/>-->
-<!--    <result property="likes" column="likes"/>-->
-
-<!--    &lt;!&ndash; PostImageDTO의 확장된 필드 매핑 &ndash;&gt;-->
-<!--    <result property="imgPath" column="img_path"/>-->
-<!--    <result property="savedImgName" column="saved_img_name"/>-->
-<!--  </resultMap>-->
+  <delete id="deleteByPostId">
+    UPDATE comment
+    SET is_deleted = 1,
+        update_date = NOW()
+    WHERE post_id = #{postId} AND is_deleted = 0
+  </delete>
 
 
-<!--  <select id="findWithPostsAndImageByUserId" resultMap="postImageDTOMap">-->
-<!--    SELECT-->
-<!--    b.post_id AS post_id,-->
-<!--    p.contents,-->
-<!--    p.likes,-->
-<!--    i.img_path,-->
-<!--    i.saved_img_name-->
-<!--    FROM-->
-<!--    bookmark AS b-->
-
-<!--    JOIN (-->
-<!--    SELECT post_id, MIN(id) AS min_image_id-->
-<!--    FROM image-->
-<!--    WHERE is_deleted = 0-->
-<!--    GROUP BY post_id-->
-<!--    ) AS min_img ON b.post_id = min_img.post_id-->
-<!--    JOIN image AS i ON min_img.post_id = i.post_id AND min_img.min_image_id = i.id-->
-<!--    JOIN post AS p ON b.post_id = p.id-->
-
-<!--    WHERE-->
-<!--    b.user_id = #{userId}-->
-<!--    AND p.is_deleted = 0-->
-<!--    <if test="lastId != null">-->
-<!--      AND b.create_date &lt; (-->
-<!--      SELECT create_date-->
-<!--      FROM bookmark-->
-<!--      WHERE post_id = #{lastId}-->
-<!--      LIMIT 1-->
-<!--      )-->
-<!--    </if>-->
-
-<!--    ORDER BY b.create_date DESC-->
-<!--    LIMIT #{size}-->
-<!--  </select>-->
 </mapper>

--- a/src/main/resources/mybatis/mapper/image.xml
+++ b/src/main/resources/mybatis/mapper/image.xml
@@ -21,7 +21,7 @@
     ORDER BY id
   </select>
 
-  <update id="deleteByIds" parameterType="java.util.List">
+  <delete id="deleteByIds" parameterType="java.util.List">
     UPDATE image
     SET is_deleted = 1,
     update_date = NOW()
@@ -29,5 +29,12 @@
     <foreach collection="list" item="id" open="(" separator="," close=")">
       #{id}
     </foreach>
-  </update>
+  </delete>
+
+  <delete id="deleteByPostId">
+    UPDATE image
+    SET is_deleted = 1,
+        update_date = NOW()
+    WHERE post_id = #{postId} AND is_deleted = 0
+  </delete>
 </mapper>

--- a/src/main/resources/mybatis/mapper/like.xml
+++ b/src/main/resources/mybatis/mapper/like.xml
@@ -21,6 +21,12 @@
       AND post_id = #{postId}
   </delete>
 
+  <delete id="deleteByPostId">
+    DELETE FROM `like`
+    WHERE post_id = #{postId}
+  </delete>
+
+
   <select id="findPostIdsByUserId" resultType="Long">
     SELECT post_id
     FROM `like`


### PR DESCRIPTION
## post 삭제 시, 관련된 테이블의 레코드 삭제
- kafka 메시지 큐에 post 삭제 메시지 전송

- consumer가 게시물 및 관련 레코드 삭제 처리 진행 
    - post, comment, image 레코드는 soft delete 처리
    - like, bookmark 레코드는 hard delete 처리