### PR TITLE
[#48] 좋아요 관련 캐싱 및 DB 동기화 작업

### DIFF
--- a/src/main/java/com/outstagram/outstagram/common/constant/RedisKeyPrefixConst.java
+++ b/src/main/java/com/outstagram/outstagram/common/constant/RedisKeyPrefixConst.java
@@ -1,0 +1,13 @@
+package com.outstagram.outstagram.common.constant;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class RedisKeyPrefixConst {
+    public static final String LIKE_COUNT_PREFIX = "likeCount:";
+
+    public static final String USER_LIKE_PREFIX = "userLike:";
+    public static final String USER_UNLIKE_PREFIX = "userUnlike:";
+
+}

--- a/src/main/java/com/outstagram/outstagram/common/scheduler/UpdateLikeScheduler.java
+++ b/src/main/java/com/outstagram/outstagram/common/scheduler/UpdateLikeScheduler.java
@@ -1,0 +1,101 @@
+package com.outstagram.outstagram.common.scheduler;
+
+import static com.outstagram.outstagram.common.constant.RedisKeyPrefixConst.LIKE_COUNT_PREFIX;
+import static com.outstagram.outstagram.common.constant.RedisKeyPrefixConst.USER_LIKE_PREFIX;
+import static com.outstagram.outstagram.common.constant.RedisKeyPrefixConst.USER_UNLIKE_PREFIX;
+
+import com.outstagram.outstagram.mapper.PostMapper;
+import com.outstagram.outstagram.service.LikeService;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@EnableScheduling
+@RequiredArgsConstructor
+public class UpdateLikeScheduler {
+
+    private final PostMapper postMapper;
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final LikeService likeService;
+
+    /**
+     * 게시물에 좋아요 개수 반영
+     */
+    @Transactional
+    @Scheduled(fixedRate = 300000)  // 5분마다 실행
+    public void updateLikes() {
+        log.info("=================== 좋아요 개수 DB에 반영 시작");
+        // likeCount:{postId} 전부 가져오기
+        Set<String> keys = redisTemplate.keys(LIKE_COUNT_PREFIX + "*");
+        if (keys != null) {
+            for (String key : keys) {
+                Long postId = Long.parseLong(key.replace(LIKE_COUNT_PREFIX, ""));
+                Integer likeCount = (Integer) redisTemplate.opsForValue().get(key);
+                if (likeCount != null) {
+                    postMapper.updateLikeCount(postId, likeCount);
+
+                    // 캐시에서 해당 키 삭제
+                    redisTemplate.delete(key);
+                }
+            }
+        }
+        log.info("=================== 좋아요 개수 DB에 반영 종료");
+    }
+
+    /**
+     * like 테이블에 좋아요 기록 insert
+     */
+    @Transactional
+    @Scheduled(fixedRate = 300000)
+    public void insertUserLike() {
+        log.info("=================== 좋아요 정보 DB에 insert 시작");
+
+        Set<String> userLikeKeys = redisTemplate.keys(USER_LIKE_PREFIX + "*");
+        if (userLikeKeys != null) {
+            for (String key : userLikeKeys) {
+                Long userId = Long.parseLong(key.replace(USER_LIKE_PREFIX, ""));
+                Set<Object> postIds = redisTemplate.opsForSet().members(key);
+                if (postIds != null) {
+                    for (Object postIdObj : postIds) {
+                        Long postId = ((Integer) postIdObj).longValue();
+                        likeService.insertLike(userId, postId);
+                    }
+                    // 캐시에서 해당 키 삭제
+                    redisTemplate.delete(key);
+                }
+            }
+        }
+        log.info("=================== 좋아요 정보 DB에 insert 종료");
+    }
+
+    @Transactional
+    @Scheduled(fixedRate = 300000)
+    public void deleteUserLike() {
+        log.info("=================== 좋아요 정보 DB에서 delete 시작");
+
+        Set<String> userUnlikeKeys = redisTemplate.keys(USER_UNLIKE_PREFIX + "*");
+        if (userUnlikeKeys != null) {
+            for (String key : userUnlikeKeys) {
+                Long userId = Long.parseLong(key.replace(USER_UNLIKE_PREFIX, ""));
+                Set<Object> postIds = redisTemplate.opsForSet().members(key);
+                if (postIds != null) {
+                    for (Object postIdObj : postIds) {
+                        Long postId = ((Integer) postIdObj).longValue();
+                        likeService.deleteLike(userId, postId);
+                    }
+                    // 캐시에서 해당 키 삭제
+                    redisTemplate.delete(key);
+                }
+            }
+        }
+        log.info("=================== 좋아요 정보 DB에서 delete 종료");
+
+    }
+}

--- a/src/main/java/com/outstagram/outstagram/controller/PostController.java
+++ b/src/main/java/com/outstagram/outstagram/controller/PostController.java
@@ -49,7 +49,7 @@ public class PostController {
 
     @GetMapping("/{postId}")
     public ResponseEntity<PostDetailsDTO> getPost(@PathVariable Long postId, @Login UserDTO user) {
-        PostDetailsDTO postDetailsDTO = postService.getPost(postId, user.getId());
+        PostDetailsDTO postDetailsDTO = postService.getPostDetails(postId, user.getId());
 
         return ResponseEntity.ok(postDetailsDTO);
     }

--- a/src/main/java/com/outstagram/outstagram/exception/errorcode/ErrorCode.java
+++ b/src/main/java/com/outstagram/outstagram/exception/errorcode/ErrorCode.java
@@ -51,6 +51,7 @@ public enum ErrorCode {
 
     // like 관련 에러 코드
     DUPLICATED_LIKE(HttpStatus.CONFLICT, "이미 좋아요한 게시물입니다."),
+    NOT_FOUND_LIKE(HttpStatus.INTERNAL_SERVER_ERROR, "좋아요 기록이 없습니다"),
 
     // bookmark 관련 에러 코드
     DUPLICATED_BOOKMARK(HttpStatus.CONFLICT, "이미 북마크한 게시물입니다."),

--- a/src/main/java/com/outstagram/outstagram/mapper/PostMapper.java
+++ b/src/main/java/com/outstagram/outstagram/mapper/PostMapper.java
@@ -18,7 +18,6 @@ public interface PostMapper {
 
     List<PostImageDTO> findWithImageByUserId(Long userId, Long lastId, int size);
 
-    int updateLikeCount(Long postId, int count, int currentVersion);
-
+    int updateLikeCount(Long postId, int count);
 
 }

--- a/src/main/java/com/outstagram/outstagram/service/LikeService.java
+++ b/src/main/java/com/outstagram/outstagram/service/LikeService.java
@@ -47,4 +47,6 @@ public class LikeService {
     public List<PostImageDTO> getLikePosts(Long userId, Long lastId) {
         return likeMapper.findWithPostsAndImageByUserId(userId, lastId, PAGE_SIZE);
     }
+
+
 }

--- a/src/main/java/com/outstagram/outstagram/service/PostService.java
+++ b/src/main/java/com/outstagram/outstagram/service/PostService.java
@@ -300,20 +300,18 @@ public class PostService {
             // 삭제 예정인 캐시에도 없으면 DB에서 확인
             if (likeService.existsLike(userId, postId)) {
                 throw new ApiException(ErrorCode.DUPLICATED_LIKE);
+            } else {
+                // 좋아요 증가
+                redisTemplate.opsForValue().increment(key, 1);
+                // 유저 좋아요 기록 캐싱
+                redisTemplate.opsForSet().add(userLikeKey, postId);
             }
+        } else {
+            // 해당 게시물에 대해 좋아요 취소한 기록이 있다면 기록 삭제
+            redisTemplate.opsForSet().remove(userUnlikeKey, postId);
+            // 좋아요 증가
+            redisTemplate.opsForValue().increment(key, 1);
         }
-
-        // Redis & DB 모두 좋아요 기록 없으면 좋아요 실제 증가 로직 수행
-
-        // 좋아요 증가
-        redisTemplate.opsForValue().increment(key, 1);
-
-        // 유저 좋아요 기록 캐싱
-        redisTemplate.opsForSet().add(userLikeKey, postId);
-
-        // 해당 게시물에 대해 좋아요 취소한 기록이 있다면 기록 삭제
-        redisTemplate.opsForSet().remove(userUnlikeKey, postId);
-
     }
 
     /**

--- a/src/main/java/com/outstagram/outstagram/service/S3ImageService.java
+++ b/src/main/java/com/outstagram/outstagram/service/S3ImageService.java
@@ -34,8 +34,6 @@ public class S3ImageService extends AbstractBaseImageService {
     @Value("${cloud.aws.s3.bucketName}")
     private String bucketName;
 
-    //private final static String UPLOAD_PATH = "https://outstagram-s3.s3.ap-northeast-2.amazonaws.com/";
-
     public S3ImageService(ImageMapper imageMapper, AmazonS3 amazonS3) {
         super(imageMapper);
         this.amazonS3 = amazonS3;

--- a/src/main/resources/mybatis/mapper/post.xml
+++ b/src/main/resources/mybatis/mapper/post.xml
@@ -56,7 +56,7 @@
 
   <!-- postId로 게시물 가져오기 -->
   <select id="findById" resultType="com.outstagram.outstagram.dto.PostDTO">
-    SELECT id, user_id, contents, likes, version
+    SELECT id, user_id, contents, likes, version, create_date, update_date
     FROM post
     WHERE id = #{postId}
       AND is_deleted = 0
@@ -82,11 +82,9 @@
 
   <update id="updateLikeCount">
     UPDATE post
-    SET likes = likes + #{count},
-        update_date = NOW(),
-        version = version + 1
+    SET likes = #{count},
+        update_date = NOW()
     WHERE id = #{postId}
-        AND version = #{currentVersion}
         AND is_deleted = 0
   </update>
 

--- a/src/test/java/com/outstagram/outstagram/service/PostServiceTest.java
+++ b/src/test/java/com/outstagram/outstagram/service/PostServiceTest.java
@@ -93,7 +93,7 @@ class PostServiceTest {
         when(imageService.getImageInfos(postId)).thenReturn(imageList);
         when(userService.getUser(userId)).thenReturn(user);
 
-        PostDetailsDTO foundPost = postService.getPost(postId, userId);
+        PostDetailsDTO foundPost = postService.getPostDetails(postId, userId);
 
         assertNotNull(foundPost);
         assertTrue(foundPost.getIsCreatedByCurrentUser());
@@ -110,7 +110,7 @@ class PostServiceTest {
         when(postMapper.findById(postId)).thenReturn(null);
 
         ApiException apiException = assertThrows(ApiException.class,
-            () -> postService.getPost(postId, userId));
+            () -> postService.getPostDetails(postId, userId));
 
         assertEquals(ErrorCode.POST_NOT_FOUND, apiException.getErrorCode());
         assertEquals("해당 게시물은 존재하지 않습니다.", apiException.getDescription());


### PR DESCRIPTION
## 좋아요 증가
- 좋아요 증가 로직 실행 시, 우선 해당 게시물 좋아요 개수 캐싱하기

- Redis에 좋아요 누른 기록 저장되어 있다면 예외 던지기 (중복 좋아요 방지)
- Redis에 좋아요 누른 기록 없음 && Redis에 좋아요 삭제 예정 캐시 있다면
    - 좋아요 삭제 예정  캐시 기록 삭제
    - 캐시된 좋아요 개수 +1
    - 이 경우에는 이미 DB에 좋아요 기록되어 있음
- Redis에 좋아요 누른 기록 없음 && Redis에 좋아요 삭제 예정 캐시 없다면
   - DB에 좋아요 기록 확인
   - DB에 좋아요 기록 있다면 예외 던지기 (중복 좋아요 방지)
   - DB에 좋아요 기록 없다면 Redis에 좋아요 기록 캐시 & 캐시된 좋아요 개수 +1

## 좋아요 취소
- 좋아요 취소 로직 실행 시, 우선 해당 게시물 좋아요 개수 캐싱하기

- Redis에 좋아요 삭제 예정 캐시 있다면 예외 던지기 (중복 좋아요 취소 방지)
- Redis에 좋아요 누른 기록 없음 && DB에도 좋아요 기록 없음 -> 예외 던지기 (중복 좋아요 취소 방지)

- Redis에 좋아요 기록 없음 && DB에는 좋아요 기록 있다면
    - Redis에 좋아요 삭제 예정 캐시
    - 캐시된 좋아요 개수 -1
- Redis에 좋아요 기록 있다면 
    - Redis 좋아요 기록 캐시 삭제
    - 캐시된 좋아요 개수 -1


## DB 동기화
- 5분마다 캐시된 기록들 DB에 반영하기

- 이렇게 하는 이유는 like의 경우 자주 증감 이벤트가 발생하기 때문에 테이블에 insert, update, delete하는 로직들이 자주 발생한다.
- 하지만 update, delete 는 비용이 비싼 쿼리이기에 캐싱해놓고 5분마다 모아서 처리하는게 더 효율적임
- 즉, 캐시에 좋아요 관련 기록들을 버퍼링해놓고 5분마다 기록들을 모아서 처리

- 5분마다 게시물의 좋아요 개수 업데이트, 게시물 좋아요 기록 추가 및 삭제 스케쥴링이 동작함
- 각 스케쥴링 동작하면서 DB에 반영할 때마다, 캐시(Redis)에서 해당 key 삭제 (DB에 반영했으니까 캐시에서는 삭제)