### PR TITLE
[#52] Redis 동시성 이슈 해결을 위한 lua script 도입

### DIFF
--- a/src/main/java/com/outstagram/outstagram/config/RedisConfig.java
+++ b/src/main/java/com/outstagram/outstagram/config/RedisConfig.java
@@ -9,11 +9,14 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
+import org.springframework.core.io.ClassPathResource;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.springframework.scripting.support.ResourceScriptSource;
 
 @Configuration
 public class RedisConfig {
@@ -54,8 +57,8 @@ public class RedisConfig {
             .build();
         objectMapper.activateDefaultTyping(ptv, ObjectMapper.DefaultTyping.NON_FINAL);
 
-        GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(objectMapper);
-
+        GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(
+            objectMapper);
 
         RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
         redisTemplate.setConnectionFactory(redisConnectionFactory());
@@ -64,6 +67,15 @@ public class RedisConfig {
         redisTemplate.setHashKeySerializer(new StringRedisSerializer());
         redisTemplate.setHashValueSerializer(serializer);
         return redisTemplate;
+    }
+
+    @Bean
+    public DefaultRedisScript<String> increaseLikeScript() {
+        DefaultRedisScript<String> redisScript = new DefaultRedisScript<>();
+        redisScript.setScriptSource(
+            new ResourceScriptSource(new ClassPathResource("scripts/increaseLike.lua")));
+        redisScript.setResultType(String.class);
+        return redisScript;
     }
 
 }

--- a/src/main/java/com/outstagram/outstagram/config/RedisConfig.java
+++ b/src/main/java/com/outstagram/outstagram/config/RedisConfig.java
@@ -78,4 +78,13 @@ public class RedisConfig {
         return redisScript;
     }
 
+    @Bean
+    public DefaultRedisScript<String> decreaseLikeScript() {
+        DefaultRedisScript<String> redisScript = new DefaultRedisScript<>();
+        redisScript.setScriptSource(
+            new ResourceScriptSource(new ClassPathResource("scripts/decreaseLike.lua")));
+        redisScript.setResultType(String.class);
+        return redisScript;
+    }
+
 }

--- a/src/main/java/com/outstagram/outstagram/dto/LikeRecordDTO.java
+++ b/src/main/java/com/outstagram/outstagram/dto/LikeRecordDTO.java
@@ -1,5 +1,6 @@
 package com.outstagram.outstagram.dto;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import java.io.Serializable;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
@@ -11,7 +12,9 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "@class")
 public class LikeRecordDTO implements Serializable {
+
     private Long postId;
     private LocalDateTime likeAt;
 

--- a/src/main/java/com/outstagram/outstagram/exception/errorcode/ErrorCode.java
+++ b/src/main/java/com/outstagram/outstagram/exception/errorcode/ErrorCode.java
@@ -57,9 +57,10 @@ public enum ErrorCode {
     DUPLICATED_BOOKMARK(HttpStatus.CONFLICT, "이미 북마크한 게시물입니다."),
     NOT_FOUND_BOOKMARK(HttpStatus.INTERNAL_SERVER_ERROR, "북마크 기록이 없습니다"),
 
-    NULL_POINT_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "null point error 입니다.");
+    NULL_POINT_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "null point error 입니다."),
+    JSON_CONVERTING_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "json <-> String 변환 과정 중 에러가 발생했습니다."),
 
-
+    ;
 
     private final HttpStatus httpStatusCode;
     private final String description;

--- a/src/main/java/com/outstagram/outstagram/service/PostService.java
+++ b/src/main/java/com/outstagram/outstagram/service/PostService.java
@@ -365,7 +365,7 @@ public class PostService {
         List<Long> idList = new ArrayList<>();
 
         if (lastId == null) {   // 첫 요청 : 캐시 -> DB
-            if (recentIdSize > 10) {      // 짜른게 10개 초과 -> 캐시만으로 해결
+            if (recentIdSize > PAGE_SIZE) {      // 짜른게 10개 초과 -> 캐시만으로 해결
                 recentLikeIdList.stream()
                     .limit(PAGE_SIZE + 1)
                     .forEach(record -> idList.add(record.getPostId()));

--- a/src/main/java/com/outstagram/outstagram/service/PostService.java
+++ b/src/main/java/com/outstagram/outstagram/service/PostService.java
@@ -29,6 +29,7 @@ import com.outstagram.outstagram.exception.errorcode.ErrorCode;
 import com.outstagram.outstagram.kafka.producer.FeedUpdateProducer;
 import com.outstagram.outstagram.kafka.producer.PostDeleteProducer;
 import com.outstagram.outstagram.mapper.PostMapper;
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -271,6 +272,7 @@ public class PostService {
             }
             likeCount = post.getLikes();
             redisTemplate.opsForValue().set(key, likeCount);
+            redisTemplate.expire(key, Duration.ofHours(1));
         } else {
             likeCount = (int) redisTemplate.opsForValue().get(key);
         }

--- a/src/main/resources/scripts/decreaseLike.lua
+++ b/src/main/resources/scripts/decreaseLike.lua
@@ -1,0 +1,36 @@
+---@diagnostic disable: undefined-global
+local likeCountKey = KEYS[1]
+local userLikeKey = KEYS[2]
+local postId = tonumber(ARGV[1])
+
+-- 사용자 좋아요 기록을 확인
+local userLikes = redis.call('lrange', userLikeKey, 0, -1)
+
+if not userLikes or #userLikes == 0 then
+    return redis.error_reply('LIKE NOT FOUND')
+end
+
+local parsedValue = {}
+local found = false
+
+for i, v in ipairs(userLikes) do
+    local decodedValue = cjson.decode(v)
+    if decodedValue.postId == postId then
+        found = true
+    else
+        table.insert(parsedValue, v)
+    end
+end
+
+if found then
+    -- Clear the original list
+    redis.call('del', userLikeKey)
+    -- Insert the remaining values back to the list
+    for _, v in ipairs(parsedValue) do
+        redis.call('rpush', userLikeKey, v)
+    end
+    redis.call('decr', likeCountKey)
+    return postId .. " removed successfully"
+else
+    return redis.error_reply('LIKE NOT FOUND')
+end

--- a/src/main/resources/scripts/decreaseLike.lua
+++ b/src/main/resources/scripts/decreaseLike.lua
@@ -23,12 +23,13 @@ for i, v in ipairs(userLikes) do
 end
 
 if found then
-    -- Clear the original list
+    -- 해당 키의 값들 지우고
     redis.call('del', userLikeKey)
-    -- Insert the remaining values back to the list
+    -- 삭제된 거 빼고 다시 값 push하기
     for _, v in ipairs(parsedValue) do
         redis.call('rpush', userLikeKey, v)
     end
+    -- 좋아요 개수 1 감소
     redis.call('decr', likeCountKey)
     return postId .. " removed successfully"
 else

--- a/src/main/resources/scripts/increaseLike.lua
+++ b/src/main/resources/scripts/increaseLike.lua
@@ -3,17 +3,9 @@ local likeCountKey = KEYS[1]
 local userLikeKey = KEYS[2]
 local likeRecord = ARGV[1]
 
--- JSON 라이브러리 로드
---local cjson = require "cjson"
-
--- JSON 문자열을 테이블로 변환
---local likeRecordTable = cjson.decode(likeRecord)
-
 -- 사용자 좋아요 기록을 확인
 local userLikes = redis.call('lrange', userLikeKey, 0, -1)
 for i, v in ipairs(userLikes) do
-    --local userLikeTable = cjson.decode(v)
-    --if userLikeTable.postId == likeRecordTable.postId then
     if v == likeRecord then
         return redis.error_reply('DUPLICATED_LIKE')
     end

--- a/src/main/resources/scripts/increaseLike.lua
+++ b/src/main/resources/scripts/increaseLike.lua
@@ -1,0 +1,27 @@
+---@diagnostic disable: undefined-global
+local likeCountKey = KEYS[1]
+local userLikeKey = KEYS[2]
+local likeRecord = ARGV[1]
+
+-- JSON 라이브러리 로드
+--local cjson = require "cjson"
+
+-- JSON 문자열을 테이블로 변환
+--local likeRecordTable = cjson.decode(likeRecord)
+
+-- 사용자 좋아요 기록을 확인
+local userLikes = redis.call('lrange', userLikeKey, 0, -1)
+for i, v in ipairs(userLikes) do
+    --local userLikeTable = cjson.decode(v)
+    --if userLikeTable.postId == likeRecordTable.postId then
+    if v == likeRecord then
+        return redis.error_reply('DUPLICATED_LIKE')
+    end
+end
+
+-- 사용자 좋아요 기록 추가 및 좋아요 수 증가를 원자적으로 처리
+redis.call('lpush', userLikeKey, likeRecord)
+redis.call('expire', userLikeKey, 3600) -- TTL 1시간 설정
+redis.call('incr', likeCountKey) -- 좋아요 개수 증가
+
+return 'OK'

--- a/src/main/resources/scripts/increaseLike.lua
+++ b/src/main/resources/scripts/increaseLike.lua
@@ -16,7 +16,6 @@ end
 
 -- 사용자 좋아요 기록 추가 및 좋아요 수 증가를 원자적으로 처리
 redis.call('lpush', userLikeKey, likeRecord)
-redis.call('expire', userLikeKey, 3600) -- TTL 1시간 설정
 redis.call('incr', likeCountKey) -- 좋아요 개수 증가
 
 return 'OK'

--- a/src/main/resources/scripts/increaseLike.lua
+++ b/src/main/resources/scripts/increaseLike.lua
@@ -3,10 +3,13 @@ local likeCountKey = KEYS[1]
 local userLikeKey = KEYS[2]
 local likeRecord = ARGV[1]
 
+local decodedLikeRecord = cjson.decode(likeRecord)
+
 -- 사용자 좋아요 기록을 확인
 local userLikes = redis.call('lrange', userLikeKey, 0, -1)
 for i, v in ipairs(userLikes) do
-    if v == likeRecord then
+    local decodedValue = cjson.decode(v)
+    if decodedValue.postId == decodedLikeRecord.postId then
         return redis.error_reply('DUPLICATED_LIKE')
     end
 end

--- a/src/test/java/com/outstagram/outstagram/service/RedisMultiThreadTest.java
+++ b/src/test/java/com/outstagram/outstagram/service/RedisMultiThreadTest.java
@@ -1,0 +1,83 @@
+package com.outstagram.outstagram.service;
+
+import com.outstagram.outstagram.exception.ApiException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.transaction.annotation.Transactional;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest
+public class RedisMultiThreadTest {
+
+    @Autowired
+    private PostService postService;
+
+
+    @Test
+    @Transactional
+    public void testConcurrentIncreaseLike() throws InterruptedException {
+        Long postId = 11L;
+        Long userId = 4L;
+
+        // Initial setup to ensure post exists and is cached
+        postService.loadLikeCountIfAbsent(postId);
+
+        ExecutorService executorService = Executors.newFixedThreadPool(2);
+
+        Runnable task = () -> {
+            try {
+                postService.increaseLike(postId, userId);
+            } catch (ApiException e) {
+                System.out.println(e.getErrorCode()); // Handle expected exception
+            }
+        };
+
+        // Execute tasks concurrently
+        executorService.execute(task);
+        executorService.execute(task);
+
+        // Shutdown executor and wait for tasks to finish
+        executorService.shutdown();
+        executorService.awaitTermination(1, TimeUnit.MINUTES);
+
+        // Further assertions or cleanup can be done here
+    }
+
+    @Test
+    @Transactional
+    public void testConcurrentDecreaseLike() throws InterruptedException {
+        Long postId = 11L;
+        Long userId = 4L;
+
+        // Initial setup to ensure post exists and is cached
+        postService.loadLikeCountIfAbsent(postId);
+
+        ExecutorService executorService = Executors.newFixedThreadPool(2);
+
+        postService.increaseLike(postId, userId);
+
+        Runnable task = () -> {
+            try {
+                postService.unlikePost(postId, userId);
+            } catch (ApiException e) {
+                System.out.println(e.getErrorCode()); // Handle expected exception
+            }
+        };
+
+        // Execute tasks concurrently
+        executorService.execute(task);
+        executorService.execute(task);
+
+        // Shutdown executor and wait for tasks to finish
+        executorService.shutdown();
+        executorService.awaitTermination(1, TimeUnit.MINUTES);
+
+        // Further assertions or cleanup can be done here
+    }
+}

--- a/src/test/java/com/outstagram/outstagram/service/RedisMultiThreadTest.java
+++ b/src/test/java/com/outstagram/outstagram/service/RedisMultiThreadTest.java
@@ -52,15 +52,13 @@ public class RedisMultiThreadTest {
     @Test
     @Transactional
     public void testConcurrentDecreaseLike() throws InterruptedException {
-        Long postId = 11L;
+        Long postId = 14L;
         Long userId = 4L;
 
         // Initial setup to ensure post exists and is cached
         postService.loadLikeCountIfAbsent(postId);
 
         ExecutorService executorService = Executors.newFixedThreadPool(2);
-
-        postService.increaseLike(postId, userId);
 
         Runnable task = () -> {
             try {


### PR DESCRIPTION
## 좋아요 증감 시 Redis의 동시성 문제 상황
- 동시에 똑같은 좋아요 증가를 요청했을 때, 둘 다 성공해서 좋아요 기록 2개, 좋아요 개수 2 증가하는 상황

    - 이유는 좋아요 존재 여부 비교, 좋아요 기록 증가, 개수 증가 operation들이 원자적으로 실행되지 않고 각각 따로 실행되기 때문
    - 동시에 좋아요 존재 여부 비교해서 통과되면 redis에 기록 가능해짐

### 해결 방안 (lua script 도입)
- redis에 좋아요 존재 여부, 있다면 좋아요 기록 & 좋아요 개수 1 증가 -> 이 3가지 로직을 atomic하게 실행할 수 있다면 동시성 문제를 해결할 수 있다

- 그래서 lua script를 통해 해당 로직을 구현해놓으면 atomic하게 실행된다